### PR TITLE
Add missing setting to desktop file

### DIFF
--- a/resource/wine.desktop
+++ b/resource/wine.desktop
@@ -5,3 +5,4 @@ Icon=Wine
 Type=Application
 Categories=Network;
 Name[en_US]=Wine
+X-AppImage-Integrate=false


### PR DESCRIPTION
This is an AppImage that should AFAICS not be integrated by tools like AppImageLauncher. Therefore this key will make tools like AppImageLauncher ignore this AppImage.

See https://github.com/TheAssassin/AppImageLauncher/issues/233 for reference.